### PR TITLE
download.html: Adds zelcore-170.apk + SHA256

### DIFF
--- a/project/zelcore/download.html
+++ b/project/zelcore/download.html
@@ -127,6 +127,7 @@
                             <div class="uk-text-center uk-margin-medium zelcoreMobile uk-hidden@l">
                                 <a href="https://itunes.apple.com/us/app/zelcore/id1436296839?mt=8" target="_blank" id="iOS"><img src="./img/zelcore/badge-appstore.svg"></a>
                                 <a href="https://play.google.com/store/apps/details?id=com.zelcash.zelcore" target="_blank" id="Android"><img src="./img/zelcore/badge-googleplay.svg"></a>
+                                <a href="https://zelcore.io/downloads/zelcore-170.apk" target="_blank" id="Android"><img src="./img/zelcore/badge-directdownload.svg"></a>
                             </div>
                             <h1 class="uk-h5"><a href="#downloads" uk-scroll>Other Platforms</a></h1>
                         </div>
@@ -179,6 +180,7 @@
                         <div class="uk-text-center uk-margin-medium zelcoreMobile">
                             <a href="https://itunes.apple.com/us/app/zelcore/id1436296839?mt=8" target="_blank"><img src="./img/zelcore/badge-appstore.svg" class="uk-margin"></a>
                             <a href="https://play.google.com/store/apps/details?id=com.zelcash.zelcore" target="_blank"><img src="./img/zelcore/badge-googleplay.svg" class="uk-margin"></a>
+                            <a href="https://zelcore.io/download/zelcore-170.apk" target="_blank"><img src="./img/zelcore/directdownload.svg" class="uk-margin"></a>
                         </div>
                         <h1 class="uk-heading-primary uk-margin-medium uk-text-center"><span class="zel">Security</span> corner</h1>
                         <div class="uk-text-center">
@@ -230,6 +232,8 @@
                 <dd>ebe7d43d0d9bd7cefa1c2daa212dbbc4796d9e61a7e31227b206cf7a7b64702d</dd>
                 <dt>zelcore3x.deb</dt>
                 <dd>09c723a23c108b6b72e707717c6103a03765eec9342e9f224beadb6d1554a98c</dd>
+                <dt>zelcore-170.apk</dt>
+                <dd>148ad666806eaaddc483455c9673372fb5e6afb77fbaab3e5d020f62eac11ab6</dd>
             </dl>
             <hr class="uk-divider-icon">
             <p>GPG Fingerprint: 4F7F EBBF 1BDD D239 7DAB  E2CF 4B69 CA27 A986 265D</p>


### PR DESCRIPTION
Need Lumi/David to create badge image of "./img/zelcore/directdownload.svg" with the same theme of currently Apple Store or Google Play download badge SVG image.